### PR TITLE
After exception in CreateReceiptAsync Orchestrator produce again Tran…

### DIFF
--- a/src/Saga.Orchestration/Factories/CommandFactory.cs
+++ b/src/Saga.Orchestration/Factories/CommandFactory.cs
@@ -46,7 +46,7 @@ namespace Saga.Orchestration.Factories
         {
             return new CancelTransferCommand
             {
-                Header = BuildEventHeaderFromTransactionId(item.Id, nameof(TransferCommand)),
+                Header = BuildEventHeaderFromTransactionId(item.Id, nameof(CancelTransferCommand)),
                 Content = new CancelTransferCommandContent
                 {
                     Transaction = new TransactionDetails


### PR DESCRIPTION
After exception in CreateReceiptAsync Orchestrator produce again TransferCommand instead CancelTransferCommand because in CommandFactory.BuildCancelTransferCommand Header has:
nameof(TransferCommand)
instead of
nameof(CancelTransferCommand)